### PR TITLE
Timefind indexer doc fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,11 @@ VERSION_FULL=$(shell git describe --tags)
 # test equality
 VERSION_MATCH=$(shell ([ "$(VERSION)" == "$(VERSION_FULL)" ] && echo "1") || echo "0")
 
+# NOTE: DESTDIR must include a trailing /
 DESTDIR=
-PREFIX=$(DESTDIR)/usr
-BINDIR=$(PREFIX)/bin
-DOCDIR=$(DESTDIR)/share/timefind-$(VERSION)
+PREFIX=/usr
+BINDIR=$(DESTDIR)$(PREFIX)/bin
+DOCDIR=$(DESTDIR)$(PREFIX)/share/timefind-$(VERSION)
 
 export GOPATH := ${PWD}
 export GO15VENDOREXPERIMENT := 1

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ VERSION_MATCH=$(shell ([ "$(VERSION)" == "$(VERSION_FULL)" ] && echo "1") || ech
 DESTDIR=
 PREFIX=$(DESTDIR)/usr
 BINDIR=$(PREFIX)/bin
-DOCDIR=$(DESTDIR)/usr/share/timefind-$(VERSION)
+DOCDIR=$(DESTDIR)/share/timefind-$(VERSION)
 
 export GOPATH := ${PWD}
 export GO15VENDOREXPERIMENT := 1

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build check-version symlink-vendor
+.PHONY: build check-version symlink-vendor timefind-man-pages
 
 SHELL=/bin/bash
 
@@ -16,6 +16,8 @@ DESTDIR=
 PREFIX=/usr
 BINDIR=$(DESTDIR)$(PREFIX)/bin
 DOCDIR=$(DESTDIR)$(PREFIX)/share/timefind-$(VERSION)
+MANDIR=$(DESTDIR)$(PREFIX)/share/man
+MAN1DIR=$(DESTDIR)$(PREFIX)/share/man/man1
 
 export GOPATH := ${PWD}
 export GO15VENDOREXPERIMENT := 1
@@ -23,7 +25,7 @@ export GO15VENDOREXPERIMENT := 1
 SYMLINK_VENDOR=0
 VENDOR_DIRS=
 
-all:: check-version symlink-vendor bin/timefind bin/timefind_indexer symlink-clean
+all:: check-version symlink-vendor bin/timefind bin/timefind_indexer symlink-clean timefind-man-pages
 
 check-version:
 	@go version > /dev/null || (echo "Go not found. You need to install go: http://golang.org/doc/install"; false)
@@ -68,7 +70,7 @@ build:
 #
 # install is what is used for the .rpm
 #
-install: install_programs install_READMEs install_LICENSE
+install: install_programs install_READMEs install_LICENSE install_man_pages
 
 install_programs: bin/timefind bin/timefind_indexer
 	-mkdir -p $(BINDIR)
@@ -84,6 +86,11 @@ install_READMEs:
 install_LICENSE:
 	-mkdir -p $(DOCDIR)
 	cp ./COPYRIGHT ./LICENSE $(DOCDIR)
+
+install_man_pages: timefind-man-pages
+	-mkdir -p $(MAN1DIR)
+	cp ./src/timefind/timefind.1 $(MAN1DIR)
+	cp ./src/timefind/indexer/timefind_indexer.1 $(MAN1DIR)
 
 clean:
 	rm -rf bin/timefind bin/timefind_indexer
@@ -137,3 +144,14 @@ release:
 	cd $$HOME/WORKING/ANT/WWW/ant_2015/software/timefind && git add $(RELEASE_FILES)
 	mv $(RELEASE_FILES) RELEASE
 
+#
+# man pages:
+#
+src/timefind/timefind.1: src/timefind/README
+	pandoc -s -f markdown -t man -o $@ $< 
+
+src/timefind/indexer/timefind_indexer.1: src/timefind/indexer/README
+	pandoc -s -f markdown -t man -o $@ $< 
+
+.PHONY:
+timefind-man-pages: src/timefind/indexer/timefind_indexer.1 src/timefind/timefind.1

--- a/src/timefind/README
+++ b/src/timefind/README
@@ -37,16 +37,16 @@ or equivalently,
 Usage
 =====
 
-Usage: timefind [-hTtuv] [-b TIMESTAMP] [-c PATH] [-e TIMESTAMP] SOURCE [SOURCE ...]
- -b, --begin=TIMESTAMP
-                    Begin interval at timestamp
- -c, --config=PATH  Path to configuration file (can be used multiple times)
- -e, --end=TIMESTAMP
-                    End interval at timestamp
- -h, --help         Show this help message and exit
- -T, --human        Output human-readable start and end time for each path
- -t, --times        Output the start and end time for each path
- -v, --verbose      Verbose progress indicators and messages
+    Usage: timefind [-hTtuv] [-b TIMESTAMP] [-c PATH] [-e TIMESTAMP] SOURCE [SOURCE ...]
+     -b, --begin=TIMESTAMP
+                        Begin interval at timestamp
+     -c, --config=PATH  Path to configuration file (can be used multiple times)
+     -e, --end=TIMESTAMP
+                        End interval at timestamp
+     -h, --help         Show this help message and exit
+     -T, --human        Output human-readable start and end time for each path
+     -t, --times        Output the start and end time for each path
+     -v, --verbose      Verbose progress indicators and messages
 
 TIMESTAMPs must be formatted in the following ways:
 

--- a/src/timefind/indexer/README
+++ b/src/timefind/indexer/README
@@ -1,7 +1,7 @@
-timefind-indexer
+timefind_indexer
 ================
 
-`timefind-indexer' reads in a configuration file describing a source and outputs an
+`timefind_indexer' reads in a configuration file describing a source and outputs an
 index in CSV format containing a list of filenames, timestamp of the earliest
 record, timestamp of the latest record, and the time that the file was last
 modified.
@@ -15,19 +15,21 @@ Dependencies and Building
 1. Build configuration file. (e.g., SOURCENAME.conf.json)
    See [Single Source Configuration File].
 
-2. Run timefind-indexer.
+2. Run timefind_indexer.
 
-    ./timefind-indexer -h
+    ./timefind_indexer -h
 
-    Usage: timefind-indexer [-huv] [-c PATH]
-     -c, --config=PATH  Path to configuration file (can be used multiple times)
-     -h, --help         Show this help message and exit
-     -u, --unixtime     write Unix time to indexes instead of RFC 3339
-     -v, --verbose      Verbose progress indicators and messages
+```
+    Usage: timefind_indexer [-huv] [-c PATH]
+      -c, --config=PATH  Path to configuration file (can be used multiple times)
+      -h, --help         Show this help message and exit
+      -u, --unixtime     write Unix time to indexes instead of RFC 3339
+      -v, --verbose      Verbose progress indicators and messages
+```
 
-   After building your configuration file, you can run the timefind-indexer:
+After building your configuration file, you can run the timefind_indexer:
 
-    ./timefind-indexer -c SOURCENAME.conf.json
+    ./timefind_indexer -c SOURCENAME.conf.json
 
 Single Source Configuration File
 ================================
@@ -57,12 +59,12 @@ A basic source file for DNS data (named "dns.conf.json") might look like this:
     }
 
 The index directory ("indexDir") is where the indexed data will be stored. 
-After the timefind-indexer has finished running, the indexes can be found in the 
+After the timefind_indexer has finished running, the indexes can be found in the 
 in a .csv file located in "indexDir".
 
 The index filename is the same as the source name.
 
-Recursive directory support: When the timefind-indexer is run, the directory structure
+Recursive directory support: When the timefind_indexer is run, the directory structure
 that is traversed when indexing "paths" is created in the "indexDir." One index
 file is created per directory. For directories containing subdirectories with
 an index file in them, the index file in the subdirectory is indexed and
@@ -89,7 +91,7 @@ Each source config file has the components "type", "paths", "include",
 and "exclude". 
 
 "type" depends on the file format and which dates you wish to record from each
-file. See [Data Types and Processors] for the types of data that the timefind-indexer
+file. See [Data Types and Processors] for the types of data that the timefind_indexer
 supports. If you don't see your data type listed, you will probably have to
 write a processor for it.
 
@@ -140,7 +142,7 @@ the matching file entries, if any.
 Data Types and Processors
 =========================
 
-The timefind-indexer reads data files and indexes the earliest and latest time found in
+The timefind_indexer reads data files and indexes the earliest and latest time found in
 each file. It has the ability to index data classified under the following
 categories:
 
@@ -170,16 +172,16 @@ categories:
 6. "sep": 
     Searches for the expression "Event Time: YYYY-MM-DD HH:MM:SS" on each line.
     Stores date listed inside the expression as a string and parses it to time.
-    If the expression is not found, timefind-indexer searches for the expression "Begin:
+    If the expression is not found, timefind_indexer searches for the expression "Begin:
     YYYY-MM-DD HH:MM:SS" on each line. The date listed inside the expression is
     stored as a string and is parsed to a time. If the expression is not found,
-    timefind-indexer uses the time listed at the beginning of each line. This time is
+    timefind_indexer uses the time listed at the beginning of each line. This time is
     either of the format "Jan 2 2006 15:04:05" or the format "Jan 2 15:04:05"
 
 7. "juniper":
     Searches for a date of the format "YYYY-MM-DD HH:MM:SS" on each line.
     Stores date as a string and parses it to time. If a date of this format is
-    not found, timefind-indexer uses the time listed at the beginning of each line. This
+    not found, timefind_indexer uses the time listed at the beginning of each line. This
     time is either of the format "Jan 2 2006 15:04:05" or the format "Jan 2
     15:04:05"
 
@@ -205,7 +207,7 @@ categories:
 
 12. "win_messages":
     Searches for a date of the format "Mon Jan 2 15:04:05 2006" on each line.
-    If a date of this format is not found, timefind-indexer searches for a date of the
+    If a date of this format is not found, timefind_indexer searches for a date of the
     format "YYYY-MM-DDTHH:MM:SS-ZZ:ZZ" on each line. Stores date as a string
     and parses it to time.
 
@@ -226,7 +228,7 @@ categories:
 
 16. "fsdb_time_col_1":
     Retrieves time found in the *first* column of an fsdb-formatted,
-    tab-delimited file.  At the moment, this timefind-indexer does not read the fsdb
+    tab-delimited file.  At the moment, this timefind_indexer does not read the fsdb
     header; it simply ignores it (along with any comments).
 
     If you're getting errors with reading timestamps, check to make sure the

--- a/src/timefind/indexer/README
+++ b/src/timefind/indexer/README
@@ -1,7 +1,7 @@
-indexer
-=======
+timefind-indexer
+================
 
-`indexer' reads in a configuration file describing a source and outputs an
+`timefind-indexer' reads in a configuration file describing a source and outputs an
 index in CSV format containing a list of filenames, timestamp of the earliest
 record, timestamp of the latest record, and the time that the file was last
 modified.
@@ -15,19 +15,19 @@ Dependencies and Building
 1. Build configuration file. (e.g., SOURCENAME.conf.json)
    See [Single Source Configuration File].
 
-2. Run indexer.
+2. Run timefind-indexer.
 
-    ./indexer -h
+    ./timefind-indexer -h
 
-    Usage: indexer [-huv] [-c PATH]
+    Usage: timefind-indexer [-huv] [-c PATH]
      -c, --config=PATH  Path to configuration file (can be used multiple times)
      -h, --help         Show this help message and exit
      -u, --unixtime     write Unix time to indexes instead of RFC 3339
      -v, --verbose      Verbose progress indicators and messages
 
-   After building your configuration file, you can run the indexer:
+   After building your configuration file, you can run the timefind-indexer:
 
-    ./indexer -c SOURCENAME.conf.json
+    ./timefind-indexer -c SOURCENAME.conf.json
 
 Single Source Configuration File
 ================================
@@ -57,12 +57,12 @@ A basic source file for DNS data (named "dns.conf.json") might look like this:
     }
 
 The index directory ("indexDir") is where the indexed data will be stored. 
-After the indexer has finished running, the indexes can be found in the 
+After the timefind-indexer has finished running, the indexes can be found in the 
 in a .csv file located in "indexDir".
 
 The index filename is the same as the source name.
 
-Recursive directory support: When the indexer is run, the directory structure
+Recursive directory support: When the timefind-indexer is run, the directory structure
 that is traversed when indexing "paths" is created in the "indexDir." One index
 file is created per directory. For directories containing subdirectories with
 an index file in them, the index file in the subdirectory is indexed and
@@ -89,7 +89,7 @@ Each source config file has the components "type", "paths", "include",
 and "exclude". 
 
 "type" depends on the file format and which dates you wish to record from each
-file. See [Data Types and Processors] for the types of data that the indexer
+file. See [Data Types and Processors] for the types of data that the timefind-indexer
 supports. If you don't see your data type listed, you will probably have to
 write a processor for it.
 
@@ -140,7 +140,7 @@ the matching file entries, if any.
 Data Types and Processors
 =========================
 
-The indexer reads data files and indexes the earliest and latest time found in
+The timefind-indexer reads data files and indexes the earliest and latest time found in
 each file. It has the ability to index data classified under the following
 categories:
 
@@ -170,16 +170,16 @@ categories:
 6. "sep": 
     Searches for the expression "Event Time: YYYY-MM-DD HH:MM:SS" on each line.
     Stores date listed inside the expression as a string and parses it to time.
-    If the expression is not found, indexer searches for the expression "Begin:
+    If the expression is not found, timefind-indexer searches for the expression "Begin:
     YYYY-MM-DD HH:MM:SS" on each line. The date listed inside the expression is
     stored as a string and is parsed to a time. If the expression is not found,
-    indexer uses the time listed at the beginning of each line. This time is
+    timefind-indexer uses the time listed at the beginning of each line. This time is
     either of the format "Jan 2 2006 15:04:05" or the format "Jan 2 15:04:05"
 
 7. "juniper":
     Searches for a date of the format "YYYY-MM-DD HH:MM:SS" on each line.
     Stores date as a string and parses it to time. If a date of this format is
-    not found, indexer uses the time listed at the beginning of each line. This
+    not found, timefind-indexer uses the time listed at the beginning of each line. This
     time is either of the format "Jan 2 2006 15:04:05" or the format "Jan 2
     15:04:05"
 
@@ -205,7 +205,7 @@ categories:
 
 12. "win_messages":
     Searches for a date of the format "Mon Jan 2 15:04:05 2006" on each line.
-    If a date of this format is not found, indexer searches for a date of the
+    If a date of this format is not found, timefind-indexer searches for a date of the
     format "YYYY-MM-DDTHH:MM:SS-ZZ:ZZ" on each line. Stores date as a string
     and parses it to time.
 
@@ -226,7 +226,7 @@ categories:
 
 16. "fsdb_time_col_1":
     Retrieves time found in the *first* column of an fsdb-formatted,
-    tab-delimited file.  At the moment, this indexer does not read the fsdb
+    tab-delimited file.  At the moment, this timefind-indexer does not read the fsdb
     header; it simply ignores it (along with any comments).
 
     If you're getting errors with reading timestamps, check to make sure the

--- a/src/timefind/indexer/timefind_indexer.1
+++ b/src/timefind/indexer/timefind_indexer.1
@@ -1,10 +1,10 @@
 .TH "" "" "" "" ""
-.SH indexer
+.SH timefind_indexer
 .PP
-`indexer\[aq] reads in a configuration file describing a source and
-outputs an index in CSV format containing a list of filenames, timestamp
-of the earliest record, timestamp of the latest record, and the time
-that the file was last modified.
+`timefind_indexer\[aq] reads in a configuration file describing a source
+and outputs an index in CSV format containing a list of filenames,
+timestamp of the earliest record, timestamp of the latest record, and
+the time that the file was last modified.
 .PP
 Using `timefind\[aq] in conjunction with these indexes, a user can
 downselect the number of files based on a time range.
@@ -14,23 +14,28 @@ Build configuration file.
 (e.g., SOURCENAME.conf.json) See Single Source Configuration
 File (#single-source-configuration-file).
 .IP "2." 3
-Run indexer.
+Run timefind_indexer.
 .RS 4
 .PP
-\&./indexer \-h
-.PP
-Usage: indexer [\-huv] [\-c PATH] \-c, \-\-config=PATH Path to
-configuration file (can be used multiple times) \-h, \-\-help Show this
-help message and exit \-u, \-\-unixtime write Unix time to indexes
-instead of RFC 3339 \-v, \-\-verbose Verbose progress indicators and
-messages
+\&./timefind_indexer \-h
 .RE
-.PP
-After building your configuration file, you can run the indexer:
 .IP
 .nf
 \f[C]
-\&./indexer\ \-c\ SOURCENAME.conf.json
+\ \ \ \ Usage:\ timefind_indexer\ [\-huv]\ [\-c\ PATH]
+\ \ \ \ \ \ \-c,\ \-\-config=PATH\ \ Path\ to\ configuration\ file\ (can\ be\ used\ multiple\ times)
+\ \ \ \ \ \ \-h,\ \-\-help\ \ \ \ \ \ \ \ \ Show\ this\ help\ message\ and\ exit
+\ \ \ \ \ \ \-u,\ \-\-unixtime\ \ \ \ \ write\ Unix\ time\ to\ indexes\ instead\ of\ RFC\ 3339
+\ \ \ \ \ \ \-v,\ \-\-verbose\ \ \ \ \ \ Verbose\ progress\ indicators\ and\ messages
+\f[]
+.fi
+.PP
+After building your configuration file, you can run the
+timefind_indexer:
+.IP
+.nf
+\f[C]
+\&./timefind_indexer\ \-c\ SOURCENAME.conf.json
 \f[]
 .fi
 .SH Single Source Configuration File
@@ -75,14 +80,14 @@ this:
 .PP
 The index directory ("indexDir") is where the indexed data will be
 stored.
-After the indexer has finished running, the indexes can be found in the
-in a .csv file located in "indexDir".
+After the timefind_indexer has finished running, the indexes can be
+found in the in a .csv file located in "indexDir".
 .PP
 The index filename is the same as the source name.
 .PP
-Recursive directory support: When the indexer is run, the directory
-structure that is traversed when indexing "paths" is created in the
-"indexDir." One index file is created per directory.
+Recursive directory support: When the timefind_indexer is run, the
+directory structure that is traversed when indexing "paths" is created
+in the "indexDir." One index file is created per directory.
 For directories containing subdirectories with an index file in them,
 the index file in the subdirectory is indexed and written to the
 directory currently being indexed.
@@ -118,7 +123,7 @@ and "exclude".
 "type" depends on the file format and which dates you wish to record
 from each file.
 See Data Types and Processors (#data-types-and-processors) for the types
-of data that the indexer supports.
+of data that the timefind_indexer supports.
 If you don\[aq]t see your data type listed, you will probably have to
 write a processor for it.
 .PP
@@ -180,8 +185,8 @@ traverse to that directory\[aq]s index and recursively process until we
 find the matching file entries, if any.
 .SH Data Types and Processors
 .PP
-The indexer reads data files and indexes the earliest and latest time
-found in each file.
+The timefind_indexer reads data files and indexes the earliest and
+latest time found in each file.
 It has the ability to index data classified under the following
 categories:
 .IP " 1." 4
@@ -214,20 +219,20 @@ time.
 on each line.
 Stores date listed inside the expression as a string and parses it to
 time.
-If the expression is not found, indexer searches for the expression
-"Begin: YYYY\-MM\-DD HH:MM:SS" on each line.
+If the expression is not found, timefind_indexer searches for the
+expression "Begin: YYYY\-MM\-DD HH:MM:SS" on each line.
 The date listed inside the expression is stored as a string and is
 parsed to a time.
-If the expression is not found, indexer uses the time listed at the
-beginning of each line.
+If the expression is not found, timefind_indexer uses the time listed at
+the beginning of each line.
 This time is either of the format "Jan 2 2006 15:04:05" or the format
 "Jan 2 15:04:05"
 .IP " 7." 4
 "juniper": Searches for a date of the format "YYYY\-MM\-DD HH:MM:SS" on
 each line.
 Stores date as a string and parses it to time.
-If a date of this format is not found, indexer uses the time listed at
-the beginning of each line.
+If a date of this format is not found, timefind_indexer uses the time
+listed at the beginning of each line.
 This time is either of the format "Jan 2 2006 15:04:05" or the format
 "Jan 2 15:04:05"
 .IP " 8." 4
@@ -254,8 +259,8 @@ Stores date as a string and parses it to time.
 .IP "12." 4
 "win_messages": Searches for a date of the format "Mon Jan 2 15:04:05
 2006" on each line.
-If a date of this format is not found, indexer searches for a date of
-the format "YYYY\-MM\-DDTHH:MM:SS\-ZZ:ZZ" on each line.
+If a date of this format is not found, timefind_indexer searches for a
+date of the format "YYYY\-MM\-DDTHH:MM:SS\-ZZ:ZZ" on each line.
 Stores date as a string and parses it to time.
 .IP "13." 4
 "wireless": Searches for the expression "Time=YYYY\-MM\-DDTHH:MM:SS" on
@@ -276,8 +281,8 @@ to time.
 .IP "16." 4
 "fsdb_time_col_1": Retrieves time found in the \f[I]first\f[] column of
 an fsdb\-formatted, tab\-delimited file.
-At the moment, this indexer does not read the fsdb header; it simply
-ignores it (along with any comments).
+At the moment, this timefind_indexer does not read the fsdb header; it
+simply ignores it (along with any comments).
 .RS 4
 .PP
 If you\[aq]re getting errors with reading timestamps, check to make sure

--- a/src/timefind/indexer/timefind_indexer.1
+++ b/src/timefind/indexer/timefind_indexer.1
@@ -1,0 +1,289 @@
+.TH "" "" "" "" ""
+.SH indexer
+.PP
+`indexer\[aq] reads in a configuration file describing a source and
+outputs an index in CSV format containing a list of filenames, timestamp
+of the earliest record, timestamp of the latest record, and the time
+that the file was last modified.
+.PP
+Using `timefind\[aq] in conjunction with these indexes, a user can
+downselect the number of files based on a time range.
+.SH Dependencies and Building
+.IP "1." 3
+Build configuration file.
+(e.g., SOURCENAME.conf.json) See Single Source Configuration
+File (#single-source-configuration-file).
+.IP "2." 3
+Run indexer.
+.RS 4
+.PP
+\&./indexer \-h
+.PP
+Usage: indexer [\-huv] [\-c PATH] \-c, \-\-config=PATH Path to
+configuration file (can be used multiple times) \-h, \-\-help Show this
+help message and exit \-u, \-\-unixtime write Unix time to indexes
+instead of RFC 3339 \-v, \-\-verbose Verbose progress indicators and
+messages
+.RE
+.PP
+After building your configuration file, you can run the indexer:
+.IP
+.nf
+\f[C]
+\&./indexer\ \-c\ SOURCENAME.conf.json
+\f[]
+.fi
+.SH Single Source Configuration File
+.PP
+Each distinct data source requires its own configuration file.
+The name of the configuration file (or source) will be the name of the
+index:
+.IP
+.nf
+\f[C]
+source\ name\ =>\ source\ configuration\ filename\ =>\ index\ filename
+dns\ \ \ \ \ \ \ \ \ =>\ dns.conf.json\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ =>\ dns.csv
+\f[]
+.fi
+.PP
+Note that the configuration filename MUST end in ".conf.json".
+.PP
+Some example valid configuration filenames:
+.IP
+.nf
+\f[C]
+dns.conf.json
+great_pcap.conf.json
+http_traffic.conf.json
+\f[]
+.fi
+.PP
+A basic source file for DNS data (named "dns.conf.json") might look like
+this:
+.IP
+.nf
+\f[C]
+{
+\ \ \ \ "indexDir":\ "/index/pcap",
+\ \ \ \ "type":\ "pcap",
+\ \ \ \ "paths":\ ["/data/pcap"],
+\ \ \ \ "include":\ ["*.gz"],
+\ \ \ \ "exclude":\ []
+}
+\f[]
+.fi
+.PP
+The index directory ("indexDir") is where the indexed data will be
+stored.
+After the indexer has finished running, the indexes can be found in the
+in a .csv file located in "indexDir".
+.PP
+The index filename is the same as the source name.
+.PP
+Recursive directory support: When the indexer is run, the directory
+structure that is traversed when indexing "paths" is created in the
+"indexDir." One index file is created per directory.
+For directories containing subdirectories with an index file in them,
+the index file in the subdirectory is indexed and written to the
+directory currently being indexed.
+.PP
+For example, if we use the above configuration file ("dns.conf.json"),
+and the directory structure is as follows:
+.IP
+.nf
+\f[C]
+/data/pcap/
+/data/pcap/a/
+/data/pcap/a/b/
+/data/pcap/c/
+\f[]
+.fi
+.PP
+The indexes will be generated in the following format:
+.IP
+.nf
+\f[C]
+/index/pcap/example.csv
+/index/pcap/a/example.csv
+/index/pcap/a/b/example.csv
+/index/pcap/c/example.csv
+\f[]
+.fi
+.PP
+See Index Format (#index-format) for more details.
+.PP
+Each source config file has the components "type", "paths", "include",
+and "exclude".
+.PP
+"type" depends on the file format and which dates you wish to record
+from each file.
+See Data Types and Processors (#data-types-and-processors) for the types
+of data that the indexer supports.
+If you don\[aq]t see your data type listed, you will probably have to
+write a processor for it.
+.PP
+"paths" is one or more filepaths containing files that you wish to
+index.
+.PP
+"include" is a file pattern that specifies which files you wish to
+index.
+"exclude" is a file pattern specifies which files you do not want
+indexed.
+.SH Index Format
+.PP
+Indexes are in CSV format:
+.IP
+.nf
+\f[C]
+filename,begin_timestamp,end_timestamp,last_modified_time
+\f[]
+.fi
+.PP
+Timestamps are in Unix timestamp format with nanosecond precision.
+.PP
+Recursive directory support: An index can contain entries that are files
+(absolute path) or directories (relative path).
+An index entry that is a directory is a pointer to the existence of an
+index within that directory and the time range it covers.
+.PP
+A sample index file "pcap.csv":
+.IP
+.nf
+\f[C]
+2010\-01\-01,\ \ \ \ \ \ \ \ \ \ \ \ 100,\ 199,\ 9999
+2010\-01\-02,\ \ \ \ \ \ \ \ \ \ \ \ 200,\ 299,\ 9999
+/data/pcap/example.gz,\ 300,\ 302,\ 9999
+\f[]
+.fi
+.PP
+Since /data/pcap/example.gz is an absolute path, that entry references a
+particular file.
+.PP
+"2010\-01\-01" and "2010\-01\-02" are directories, which means we need
+to look into "2010\-01\-01/pcap.csv" and "2010\-01\-02/pcap.csv" to
+potentially pull out files in a given time range.
+.PP
+The index file "2010\-01\-01/pcap.csv" might look something like:
+.IP
+.nf
+\f[C]
+/data/pcap/2010\-01\-01/ab1.gz,\ 100,\ 105,\ 9999
+/data/pcap/2010\-01\-01/cd2.gz,\ 103,\ 107,\ 9999
+/data/pcap/2010\-01\-01/ef3.gz,\ 180,\ 199,\ 9999
+another_directory,\ \ \ \ \ \ \ \ \ \ \ \ 150,\ 180,\ 9999
+\f[]
+.fi
+.PP
+Again, after searching this index, if an index entry that matches our
+desired time range is a directory (denoted by a relative path), we
+traverse to that directory\[aq]s index and recursively process until we
+find the matching file entries, if any.
+.SH Data Types and Processors
+.PP
+The indexer reads data files and indexes the earliest and latest time
+found in each file.
+It has the ability to index data classified under the following
+categories:
+.IP " 1." 4
+"cpp":
+.RS 4
+.PP
+Unix timestamp is the first number listed on each line.
+Stores timestamp as a string and parses it to time.
+.RE
+.IP " 2." 4
+"bomgar": Searches for the expression "when=\[aq]Unix timestamp\[aq]" on
+each line.
+Stores timestamp as a string and parses it to time.
+.IP " 3." 4
+"bluecoat": Searches for a date of the format "YYYY\-MM\-DD HH:MM:SS" on
+each line.
+Stores date as a string and parses it to time.
+.IP " 4." 4
+"codevision": Searches for the expression
+"timestamp=YYYY\-MM\-DDTHH:MM:SS\-ZZ:ZZ" on each line.
+Stores date listed inside the expressison as a string and parses it to
+time.
+.IP " 5." 4
+"cer": Searches for the expression "receieved=\[aq]YYYY\-MM\-DD
+HH:MM:SS.SSSSSS\-ZZ:ZZ\[aq]" on each line.
+Stores date listed inside the expression as a string and parses it to
+time.
+.IP " 6." 4
+"sep": Searches for the expression "Event Time: YYYY\-MM\-DD HH:MM:SS"
+on each line.
+Stores date listed inside the expression as a string and parses it to
+time.
+If the expression is not found, indexer searches for the expression
+"Begin: YYYY\-MM\-DD HH:MM:SS" on each line.
+The date listed inside the expression is stored as a string and is
+parsed to a time.
+If the expression is not found, indexer uses the time listed at the
+beginning of each line.
+This time is either of the format "Jan 2 2006 15:04:05" or the format
+"Jan 2 15:04:05"
+.IP " 7." 4
+"juniper": Searches for a date of the format "YYYY\-MM\-DD HH:MM:SS" on
+each line.
+Stores date as a string and parses it to time.
+If a date of this format is not found, indexer uses the time listed at
+the beginning of each line.
+This time is either of the format "Jan 2 2006 15:04:05" or the format
+"Jan 2 15:04:05"
+.IP " 8." 4
+"email": Searches for the expression "[DATETIME]YYYY.MM.DD
+HH:MM:SS.SSSSSSS" on each line.
+Stores date listed inside the expression as a string and parses it to
+time.
+.IP " 9." 4
+"text": Stores the time listed at the beginning of each line as a string
+and parses it to time.
+This time is either of the format "Jan 2 2006 15:04:05 or the format
+"Jan 2 15:04:05"
+.IP "10." 4
+"snare": Searches for a date of the format "Mon Jan 02 15:04:05 2006" on
+each line.
+Stores date as a string and parses it to time.
+If a date of this format is not found, the time listed at the beginning
+of each line is used.
+This time is of the format "YYYY\-MM\-DDTHH:MM:SS\-ZZZZ"
+.IP "11." 4
+"iod": Searches for a date of the format "YYYY\-MM\-DDTHH:MM:SS\-ZZZZ"
+on each line.
+Stores date as a string and parses it to time.
+.IP "12." 4
+"win_messages": Searches for a date of the format "Mon Jan 2 15:04:05
+2006" on each line.
+If a date of this format is not found, indexer searches for a date of
+the format "YYYY\-MM\-DDTHH:MM:SS\-ZZ:ZZ" on each line.
+Stores date as a string and parses it to time.
+.IP "13." 4
+"wireless": Searches for the expression "Time=YYYY\-MM\-DDTHH:MM:SS" on
+each line.
+Stores date listed inside the expression as a string and parses it to
+time.
+If the expression is not found, the date listed at the beginning of each
+line is used.
+This time is either of the format "Jan 2 15:04:05 2006" or the format
+"Jan 2 15:04:05"
+.IP "14." 4
+"stealthwatch": Searches for a date of the format
+"YYYY\-MM\-DDTHH:MM:SS" on each line.
+Stores the date listed inside the expression as a string and parses it
+to time.
+.IP "15." 4
+"pcap": Retrieves time found in pcap file type
+.IP "16." 4
+"fsdb_time_col_1": Retrieves time found in the \f[I]first\f[] column of
+an fsdb\-formatted, tab\-delimited file.
+At the moment, this indexer does not read the fsdb header; it simply
+ignores it (along with any comments).
+.RS 4
+.PP
+If you\[aq]re getting errors with reading timestamps, check to make sure
+the file is tab\-delimited.
+.RE
+.IP "17." 4
+"fsdb_time_col_2": Retrieves time found in the \f[I]second\f[] column of
+an fsdb\-formatted, tab\-delimited file.
+See "fsdb_time_col_1" for additional details.

--- a/src/timefind/timefind.1
+++ b/src/timefind/timefind.1
@@ -1,0 +1,91 @@
+.TH "" "" "" "" ""
+.SH timefind
+.PP
+Given a large data store, a user may only need a subset of data for
+processing.
+For example, a user may only want to process a month\[aq]s worth of data
+(e.g., January 2015) instead of the entire collection.
+.PP
+Given a time range,
+\f[C]timefind\[aq]\ retrieves\ the\ filenames\ from\ an\ index\ generated\ by\f[]indexer\[aq]
+that overlap with the time range.
+.PP
+For example, to retrieve all DNS data from January 2015, we might run
+timefind as follows:
+.IP
+.nf
+\f[C]
+timefind\ \-\-begin="2015\-01\-01"\ \-\-end="2015\-02\-01"\ dns
+\f[]
+.fi
+.SH Single Source Configuration File
+.PP
+\f[C]timefind\[aq]\ requires\ an\ index\ generated\ by\f[]indexer\[aq],
+and uses the same configuration files used by `indexer\[aq].
+.PP
+Each distinct data source requires its own configuration file.
+The name of the configuration file (or source) will be the name of the
+index:
+.IP
+.nf
+\f[C]
+source\ name\ =>\ source\ configuration\ filename\ =>\ index\ filename
+dns\ \ \ \ \ \ \ \ \ =>\ dns.conf.json\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ =>\ dns.csv
+\f[]
+.fi
+.PP
+For example, our earlier example uses the source "dns" and uses the
+configuration file "dns.conf.json" to locate the appropriate index:
+.IP
+.nf
+\f[C]
+timefind\ \-\-begin="2015\-01\-01"\ \-\-end="2015\-02\-01"\ dns
+\f[]
+.fi
+.PP
+or equivalently,
+.IP
+.nf
+\f[C]
+timefind\ \-\-begin="2015\-01\-01"\ \-\-end="2015\-02\-01"\ \-\-config="dns.conf.json"
+\f[]
+.fi
+.SH Usage
+.IP
+.nf
+\f[C]
+Usage:\ timefind\ [\-hTtuv]\ [\-b\ TIMESTAMP]\ [\-c\ PATH]\ [\-e\ TIMESTAMP]\ SOURCE\ [SOURCE\ ...]
+\ \-b,\ \-\-begin=TIMESTAMP
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ Begin\ interval\ at\ timestamp
+\ \-c,\ \-\-config=PATH\ \ Path\ to\ configuration\ file\ (can\ be\ used\ multiple\ times)
+\ \-e,\ \-\-end=TIMESTAMP
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ End\ interval\ at\ timestamp
+\ \-h,\ \-\-help\ \ \ \ \ \ \ \ \ Show\ this\ help\ message\ and\ exit
+\ \-T,\ \-\-human\ \ \ \ \ \ \ \ Output\ human\-readable\ start\ and\ end\ time\ for\ each\ path
+\ \-t,\ \-\-times\ \ \ \ \ \ \ \ Output\ the\ start\ and\ end\ time\ for\ each\ path
+\ \-v,\ \-\-verbose\ \ \ \ \ \ Verbose\ progress\ indicators\ and\ messages
+\f[]
+.fi
+.PP
+TIMESTAMPs must be formatted in the following ways:
+.IP
+.nf
+\f[C]
+YYYY\-MM\-DD\ \ \ (e.g.,\ 2015\-01\-01)
+RFC3339\ \ \ \ \ \ (e.g.,\ 2006\-01\-02T15:04:05Z)
+RFC3339Nano\ \ (e.g.,\ 2006\-01\-02T15:04:05.999999999\-07:00)
+Unix\ time\ \ \ \ (e.g.,\ 1302561463.372802000)
+\f[]
+.fi
+.PP
+Example: the following will list files that contain data for the day of
+2015\-07\-01 from the "ydns" source:
+.IP
+.nf
+\f[C]
+timefind\ \\
+\ \ \-\-config="ydns.conf.json"\ \\
+\ \ \-\-begin="2015\-07\-01"\ \\
+\ \ \-\-end="2015\-07\-02"
+\f[]
+.fi


### PR DESCRIPTION
The binary installed differs from the documentation; this fixes that
(and also fixes a formatting issue with markdown conversion)
